### PR TITLE
Remove repo root path prefix when generating chapel junit report.

### DIFF
--- a/util/test_chapel.bash
+++ b/util/test_chapel.bash
@@ -26,7 +26,11 @@ cd $EXM_DIR
 
 log_info "Running start_test..."
 test_log=$REPO_ROOT/chapel-results.log
-start_test --logfile $test_log --no-chpl-home-warn --junit-xml-file $REPO_ROOT/chapel-tests.xml .
+start_test \
+    --logfile $test_log \
+    --no-chpl-home-warn \
+    --junit-xml-file $REPO_ROOT/chapel-tests.xml \
+    --junit-remove-prefix $REPO_ROOT
 
 # Analyze the results (someday, start_test might use exit codes to indicate
 # pass/fail...)


### PR DESCRIPTION
Also, reformat args to start_test -- the line was getting pretty long.
