### PR TITLE
Pin Sphinx version to 2.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+python: 2.7
 before_script:
   - sudo apt-get update -qq
   - sudo apt-get install -qq bc tcsh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pybtex
 Pygments>=2.0
-Sphinx==2.1.1
+Sphinx<2.1.2
 sphinx_rtd_theme
 sphinxcontrib-bibtex

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pybtex
 Pygments>=2.0
-Sphinx
+Sphinx==2.1.1
 sphinx_rtd_theme
 sphinxcontrib-bibtex


### PR DESCRIPTION
Sphinx 2.1.2 requires Python 3.5 or better.  While we look into updating our
testing system to use a newer version of Python, avoid testing failures by
pining to a version we know works